### PR TITLE
Restricted PHP version to 7.4.x only

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^7.2|^8.0",
+        "php": "~7.4.0",
         "phpstan/phpstan": "^1.9"
     },
     "require-dev": {


### PR DESCRIPTION
Closes #10
BREAKING CHANGE: Restricts PHP to version 7.4 (previously 7.2-8.x)