### PR TITLE
Do not distribute tests and dev tool configs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+* text=auto eol=lf
+
+# Do not include the following files when creating repo artifacts, e.g. the zip
+/.* export-ignore
+/tests/ export-ignore
+/docker-compose.yml export-ignore
+/phpinsights.php export-ignore
+/phpstan.neon.dist export-ignore
+/phpunit.xml export-ignore


### PR DESCRIPTION
First of all I'd like to say thanks for this brilliant extension it really helps to make existing code better

This PR adds `.gitattributes`  in order to not distribute tests, dev tools configs to the end users.