### PR TITLE
Add support to loading components on the fly

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -31,6 +31,9 @@ services:
   - class: ARiddlestone\PHPStanCakePHP2\Service\SchemaService
     arguments:
       schemaPaths: %SchemaService.schemaPaths%
+  - class: ARiddlestone\PHPStanCakePHP2\LoadComponentOnFlyMethodReturnTypeExtension
+    tags:
+      - phpstan.broker.dynamicMethodReturnTypeExtension
 parametersSchema:
   ModelBehaviorsExtension: structure([
     behaviorPaths: listOf(string())

--- a/src/LoadComponentOnFlyMethodReturnTypeExtension.php
+++ b/src/LoadComponentOnFlyMethodReturnTypeExtension.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ARiddlestone\PHPStanCakePHP2;
+
+use Component;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+class LoadComponentOnFlyMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    private ReflectionProvider $reflectionProvider;
+
+    public function __construct(ReflectionProvider $reflectionProvider)
+    {
+        $this->reflectionProvider = $reflectionProvider;
+    }
+
+    public function getClass(): string
+    {
+        return \ComponentCollection::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'load';
+    }
+
+    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): ?Type
+    {
+        $arg = $methodCall->getArgs()[0]->value;
+
+        if (!$arg instanceof String_) {
+            return null;
+        }
+
+        $componentName = $arg->value . 'Component';
+
+        if (!$this->reflectionProvider->hasClass($componentName)) {
+            return null;
+        }
+
+        if (!$this->reflectionProvider->getClass($componentName)->is(Component::class)) {
+            return null;
+        }
+
+        return new ObjectType($componentName);
+    }
+}

--- a/tests/Feature/LoadComponentOnFlyMethodReturnTypeExtensionTest.php
+++ b/tests/Feature/LoadComponentOnFlyMethodReturnTypeExtensionTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ARiddlestone\PHPStanCakePHP2\Test\Feature;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+
+class LoadComponentOnFlyMethodReturnTypeExtensionTest extends TypeInferenceTestCase
+{
+    /**
+     * @return mixed[]
+     */
+    public function dataFileAsserts(): iterable
+    {
+        yield from self::gatherAssertTypes(__DIR__ . '/data/loading_component_loaded_on_fly.php');
+    }
+
+    /**
+     * @dataProvider dataFileAsserts
+     * @param mixed $args
+     */
+    public function testControllerExtensions(string $assertType, string $file, ...$args): void
+    {
+        $this->assertFileAsserts($assertType, $file, ...$args);
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [
+            __DIR__ . '/data/phpstan.neon',
+        ];
+    }
+}

--- a/tests/Feature/data/loading_component_loaded_on_fly.php
+++ b/tests/Feature/data/loading_component_loaded_on_fly.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types = 1);
+
+use function PHPStan\Testing\assertType;
+
+/** @var BasicController $controller */
+$component = $controller->Components->load('Basic');
+
+assertType('BasicComponent', $component);


### PR DESCRIPTION
This PR bringing support detecting return type of components loaded on the fly requested in https://github.com/ariddlestone/phpstan-cakephp2/issues/30