### PR TITLE
Teach extension to see a difference between Component and Model

### DIFF
--- a/src/ClassComponentsExtension.php
+++ b/src/ClassComponentsExtension.php
@@ -4,17 +4,56 @@ declare(strict_types=1);
 
 namespace ARiddlestone\PHPStanCakePHP2;
 
-final class ClassComponentsExtension extends ClassPropertiesExtension
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\PropertiesClassReflectionExtension;
+use PHPStan\Reflection\PropertyReflection;
+use PHPStan\Reflection\ReflectionProvider;
+
+final class ClassComponentsExtension implements PropertiesClassReflectionExtension
 {
-    protected function getPropertyParentClassName(): string
+    private ReflectionProvider $reflectionProvider;
+
+    public function __construct(ReflectionProvider $reflectionProvider)
     {
-        return 'Component';
+        $this->reflectionProvider = $reflectionProvider;
+    }
+
+    public function hasProperty(ClassReflection $classReflection, string $propertyName): bool
+    {
+        if (!array_filter($this->getContainingClassNames(), [$classReflection, 'is'])) {
+            return false;
+        }
+
+        $isDefinedInComponentsProperty = (bool) array_filter(
+            $this->getDefinedComponentsAsList($classReflection),
+            static fn (string $componentName): bool => $componentName === $propertyName
+        );
+
+        if (!$isDefinedInComponentsProperty) {
+            return false;
+        }
+
+        $propertyClassName = $this->getClassNameFromPropertyName($propertyName);
+
+        return $this->reflectionProvider->hasClass($propertyClassName)
+            && $this->reflectionProvider->getClass($propertyClassName)
+                ->is('Component');
+    }
+
+    public function getProperty(ClassReflection $classReflection, string $propertyName): PropertyReflection
+    {
+        return new PublicReadOnlyPropertyReflection(
+            $this->getClassNameFromPropertyName($propertyName),
+            $classReflection
+        );
     }
 
     /**
      * @return array<string>
      */
-    protected function getContainingClassNames(): array
+    private function getContainingClassNames(): array
     {
         return [
             'Controller',
@@ -22,9 +61,38 @@ final class ClassComponentsExtension extends ClassPropertiesExtension
         ];
     }
 
-    protected function getClassNameFromPropertyName(
-        string $propertyName
-    ): string {
+    private function getClassNameFromPropertyName(string $propertyName): string
+    {
         return $propertyName . 'Component';
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getDefinedComponentsAsList(ClassReflection $classReflection): array
+    {
+        $definedComponents = [];
+
+        foreach (array_merge([$classReflection], $classReflection->getParents()) as $class) {
+            if (!$class->hasProperty('components')) {
+                continue;
+            }
+
+            $defaultValue = $class->getNativeProperty('components')
+                ->getNativeReflection()
+                ->getDefaultValueExpression();
+
+            if (!$defaultValue instanceof Array_) {
+               continue;
+            }
+
+            foreach ($defaultValue->items as $item) {
+                if ($item !== null && $item->value instanceof String_) {
+                    $definedComponents[] = $item->value->value;
+                }
+            }
+        }
+
+        return $definedComponents;
     }
 }

--- a/tests/Feature/ComponentExtensionsTest.php
+++ b/tests/Feature/ComponentExtensionsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ARiddlestone\PHPStanCakePHP2\Test\Feature;
 
 use PHPStan\Testing\TypeInferenceTestCase;

--- a/tests/Feature/ControllerExtensionsTest.php
+++ b/tests/Feature/ControllerExtensionsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ARiddlestone\PHPStanCakePHP2\Test\Feature;
 
 use PHPStan\Testing\TypeInferenceTestCase;
@@ -14,6 +16,8 @@ class ControllerExtensionsTest extends TypeInferenceTestCase
         yield from $this->gatherAssertTypes(__DIR__ . '/data/existing_controller_model.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/existing_controller_component.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/invalid_controller_property.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/existing_controller_component_with_same_method_name_as_model.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/existing_controller_component_from_parent_controller.php');
     }
 
     /**

--- a/tests/Feature/classes/Controller/BaseController.php
+++ b/tests/Feature/classes/Controller/BaseController.php
@@ -1,6 +1,8 @@
 <?php
 
-class BasicController extends Controller
+declare(strict_types=1);
+
+class BaseController extends Controller
 {
     /**
      * @var array<array-key, string>

--- a/tests/Feature/classes/Controller/Component/BasicComponent.php
+++ b/tests/Feature/classes/Controller/Component/BasicComponent.php
@@ -1,3 +1,9 @@
 <?php
 
-class BasicComponent extends Component {}
+class BasicComponent extends Component
+{
+    /**
+     * @var array<array-key, string>
+     */
+    public $components = ['Second'];
+}

--- a/tests/Feature/classes/Controller/Component/SameAsModelComponent.php
+++ b/tests/Feature/classes/Controller/Component/SameAsModelComponent.php
@@ -1,0 +1,9 @@
+<?php
+
+class SameAsModelComponent extends Component
+{
+    public function sameMethod(): int
+    {
+        return 1;
+    }
+}

--- a/tests/Feature/classes/Controller/SameAsModelController.php
+++ b/tests/Feature/classes/Controller/SameAsModelController.php
@@ -1,0 +1,9 @@
+<?php
+
+class SameAsModelController extends BaseController
+{
+    /**
+     * @var array<array-key, string>
+     */
+    public $components = ['SameAsModel'];
+}

--- a/tests/Feature/classes/Model/SameAsModel.php
+++ b/tests/Feature/classes/Model/SameAsModel.php
@@ -1,0 +1,9 @@
+<?php
+
+class SameAsModel extends Model
+{
+    public function sameMethod(): string
+    {
+        return 'test';
+    }
+}

--- a/tests/Feature/data/existing_controller_component_from_parent_controller.php
+++ b/tests/Feature/data/existing_controller_component_from_parent_controller.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types = 1);
+
+use function PHPStan\Testing\assertType;
+
+/** @var SameAsModelController $controller */
+$component = $controller->Basic;
+
+assertType('BasicComponent', $component);

--- a/tests/Feature/data/existing_controller_component_with_same_method_name_as_model.php
+++ b/tests/Feature/data/existing_controller_component_with_same_method_name_as_model.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types = 1);
+
+use function PHPStan\Testing\assertType;
+
+/** @var SameAsModelController $controller */
+$component = $controller->SameAsModel->sameMethod();
+
+assertType('int', $component);


### PR DESCRIPTION
This PR teachs extension to see the difference between Components and Models. This improvement helps to solve https://github.com/ariddlestone/phpstan-cakephp2/issues/29.

Seee tests for more details.